### PR TITLE
Add web interface with Next.js and FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # MTG-Security-Chatbot
-This is a security mining chatbot that answer questions about equipments in mining operations and the procedures to demount and mount OTR tires
+
+This project contains a mining security chatbot implemented in Python. The bot can be used from the terminal or through a simple web interface.
+
+## Running the CLI bot
+
+```bash
+pip install -r requirements.txt
+python scripts/chatbot.py
+```
+
+## Running the web interface
+
+1. Start the FastAPI backend:
+
+```bash
+python scripts/web_server.py
+```
+
+The API will be available on `http://localhost:8000`.
+
+2. In another terminal start the Next.js frontend:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Then open `http://localhost:3000` in your browser. The interface uses Kaltire's colours (black `#000000`, orange `#ff6900`, and white).
+
+The frontend is built with Next.js and tRPC as a lightweight example of the Next + tRPC + Prisma + PostgreSQL stack, although no database is required for local usage.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mtg-security-chatbot-web",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@trpc/client": "^10.0.0",
+    "@trpc/server": "^10.0.0",
+    "@trpc/react-query": "^10.0.0",
+    "@tanstack/react-query": "^4.29.0",
+    "next": "13.4.19",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "zod": "^3.22.0"
+  }
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,0 +1,27 @@
+import '../styles/globals.css'
+import type { AppProps } from 'next/app'
+import { trpc } from '../utils/trpc'
+import { httpBatchLink } from '@trpc/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useState } from 'react'
+
+function MyApp({ Component, pageProps }: AppProps) {
+  const [queryClient] = useState(() => new QueryClient())
+  const [trpcClient] = useState(() =>
+    trpc.createClient({
+      links: [
+        httpBatchLink({ url: '/api/trpc' }),
+      ],
+    })
+  )
+
+  return (
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>
+        <Component {...pageProps} />
+      </QueryClientProvider>
+    </trpc.Provider>
+  )
+}
+
+export default MyApp

--- a/frontend/src/pages/api/trpc/[trpc].ts
+++ b/frontend/src/pages/api/trpc/[trpc].ts
@@ -1,0 +1,23 @@
+import { createNextApiHandler } from '@trpc/server/adapters/next'
+import { initTRPC } from '@trpc/server'
+import { z } from 'zod'
+
+const t = initTRPC.create()
+
+export const appRouter = t.router({
+  sendMessage: t.procedure
+    .input(z.object({ message: z.string() }))
+    .mutation(async ({ input }) => {
+      const res = await fetch('http://localhost:8000/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: input.message }),
+      })
+      const data = await res.json()
+      return data
+    }),
+})
+
+export type AppRouter = typeof appRouter
+
+export default createNextApiHandler({ router: appRouter })

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { trpc } from '../utils/trpc'
+
+export default function Home() {
+  const [input, setInput] = useState('')
+  const [messages, setMessages] = useState<{ user: string; bot: string }[]>([])
+
+  const mutation = trpc.sendMessage.useMutation({
+    onSuccess(data) {
+      setMessages(prev => [...prev, { user: input, bot: data.response }])
+      setInput('')
+    },
+  })
+
+  return (
+    <div className="container">
+      <h1>MTG Security Chatbot</h1>
+      <div className="chat-box">
+        {messages.map((m, i) => (
+          <div key={i} className="message">
+            <strong>Usuario:</strong> {m.user}
+            <br />
+            <strong>Bot:</strong> {m.bot}
+          </div>
+        ))}
+      </div>
+      <form
+        onSubmit={e => {
+          e.preventDefault()
+          mutation.mutate({ message: input })
+        }}
+        className="input-form"
+      >
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Escribe tu mensaje"
+        />
+        <button type="submit">Enviar</button>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,0 +1,51 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+  background-color: #000000;
+  color: white;
+}
+
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+h1 {
+  color: #ff6900;
+  text-align: center;
+}
+
+.chat-box {
+  background-color: #222;
+  padding: 1rem;
+  height: 400px;
+  overflow-y: auto;
+  margin-bottom: 1rem;
+  border-radius: 4px;
+}
+
+.message {
+  margin-bottom: 1rem;
+}
+
+.input-form {
+  display: flex;
+  gap: 0.5rem;
+}
+
+input {
+  flex: 1;
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: none;
+}
+
+button {
+  background-color: #ff6900;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/frontend/src/utils/trpc.ts
+++ b/frontend/src/utils/trpc.ts
@@ -1,0 +1,4 @@
+import { createTRPCReact } from '@trpc/react-query'
+import type { AppRouter } from '../pages/api/trpc/[trpc]'
+
+export const trpc = createTRPCReact<AppRouter>()

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ openai
 tiktoken
 faiss-cpu
 matplotlib
+uvicorn

--- a/scripts/web_server.py
+++ b/scripts/web_server.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import re
+from fastapi import FastAPI
+from pydantic import BaseModel
+import uvicorn
+
+from functions.chat_utils import (
+    build_chat_chain,
+    extract_python_code,
+    remove_python_code_block,
+    execute_and_save_plot,
+    extract_url_from_source_documents,
+)
+
+app = FastAPI()
+chain = build_chat_chain()
+
+
+class ChatRequest(BaseModel):
+    message: str
+
+
+@app.post("/chat")
+def chat(request: ChatRequest):
+    response = chain.invoke({"question": request.message})
+    answer = response["answer"]
+    source_docs = response.get("source_documents", [])
+
+    code = extract_python_code(answer)
+    clean_text = remove_python_code_block(answer)
+    image_path = None
+    if code:
+        code_str = re.sub(r"plt\.savefig\(.*?\)", "", code, flags=re.DOTALL)
+        image_path = execute_and_save_plot(code_str)
+
+    url_found = extract_url_from_source_documents(source_docs)
+    return {
+        "response": clean_text,
+        "image": image_path,
+        "url": url_found,
+    }
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+


### PR DESCRIPTION
## Summary
- set up a `scripts/web_server.py` FastAPI endpoint for the chatbot
- extend `requirements.txt` with uvicorn dependency
- create a minimal Next.js frontend with tRPC in `frontend/`
- style the page using Kaltire colour scheme
- update README with instructions for CLI and web usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684999ffffbc832ea23bd636e006e528