### PR TITLE
Disable Next.js telemetry

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,9 +6,9 @@
     "node": ">=18 <22"
   },
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start"
+    "dev": "NEXT_TELEMETRY_DISABLED=1 next dev",
+    "build": "NEXT_TELEMETRY_DISABLED=1 next build",
+    "start": "NEXT_TELEMETRY_DISABLED=1 next start"
   },
   "dependencies": {
     "@trpc/client": "^10.0.0",


### PR DESCRIPTION
## Summary
- disable Next telemetry by setting `NEXT_TELEMETRY_DISABLED=1` in npm scripts

## Testing
- `pytest -q`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a8f32a2c832ea79ffc2f3e389037