### PR TITLE
Add manual management page and PDF viewer

### DIFF
--- a/frontend/src/pages/api/trpc/[trpc].ts
+++ b/frontend/src/pages/api/trpc/[trpc].ts
@@ -16,6 +16,19 @@ export const appRouter = t.router({
       const data = await res.json()
       return data
     }),
+  listManuals: t.procedure.query(async () => {
+    const res = await fetch('http://localhost:8000/manuals')
+    const data = await res.json()
+    return data.files as string[]
+  }),
+  deleteManual: t.procedure
+    .input(z.object({ filename: z.string() }))
+    .mutation(async ({ input }) => {
+      await fetch(`http://localhost:8000/manuals/${encodeURIComponent(input.filename)}`, {
+        method: 'DELETE',
+      })
+      return true
+    }),
 })
 
 export type AppRouter = typeof appRouter

--- a/frontend/src/pages/config.tsx
+++ b/frontend/src/pages/config.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+import { trpc } from '../utils/trpc'
+
+export default function Config() {
+  const manualsQuery = trpc.listManuals.useQuery()
+  const deleteManual = trpc.deleteManual.useMutation({
+    onSuccess: () => manualsQuery.refetch(),
+  })
+
+  const [file, setFile] = useState<File | null>(null)
+
+  const upload = async () => {
+    if (!file) return
+    const form = new FormData()
+    form.append('file', file)
+    await fetch('http://localhost:8000/manuals', { method: 'POST', body: form })
+    setFile(null)
+    manualsQuery.refetch()
+  }
+
+  return (
+    <div className="container">
+      <h1>Configuración</h1>
+      <div>
+        <input type="file" accept="application/pdf" onChange={e => setFile(e.target.files?.[0] ?? null)} />
+        <button onClick={upload}>Agregar manual</button>
+      </div>
+      <ul>
+        {manualsQuery.data?.map(m => (
+          <li key={m} className="manual-item">
+            <span className="pdf-icon">📄</span> {m}
+            <button onClick={() => deleteManual.mutate({ filename: m })}>Eliminar</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -9,6 +9,7 @@ export default function Home() {
     bot: string
     url?: string | null
   }[]>([])
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null)
 
   const mutation = trpc.sendMessage.useMutation({
     onSuccess(data) {
@@ -16,6 +17,9 @@ export default function Home() {
         ...prev,
         { user: input, bot: data.response, url: data.url },
       ])
+      if (data.url) {
+        setPdfUrl(data.url.replace('./', 'http://localhost:8000/'))
+      }
       setInput('')
     },
   })
@@ -23,23 +27,24 @@ export default function Home() {
   return (
     <div className="container">
       <h1>MTG Security Chatbot</h1>
-      <div className="chat-box">
-        {messages.map((m, i) => (
-          <div key={i} className="message">
-            <div className="user"><strong>Usuario:</strong> {m.user}</div>
-            <div className="bot">
-              <strong>Bot:</strong>{' '}
-              <ReactMarkdown>{m.bot}</ReactMarkdown>
-              {m.url && (
-                <div className="card">
-                  <a href={m.url} target="_blank" rel="noopener noreferrer">
-                    Abrir documento
-                  </a>
+      <a href="/config">Configuración</a>
+      <div className="layout">
+        <div className="chat-area">
+          <div className="chat-box">
+            {messages.map((m, i) => (
+              <div key={i} className="message">
+                <div className="user"><strong>Usuario:</strong> {m.user}</div>
+                <div className="bot">
+                  <strong>Bot:</strong>{' '}
+                  <ReactMarkdown>{m.bot}</ReactMarkdown>
                 </div>
-              )}
-            </div>
+              </div>
+            ))}
           </div>
-        ))}
+        </div>
+        {pdfUrl && (
+          <iframe className="pdf-viewer" src={pdfUrl} title="Manual" />
+        )}
       </div>
       <form
         onSubmit={e => {

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -6,9 +6,39 @@ body {
 }
 
 .container {
-  max-width: 800px;
+  max-width: 900px;
   margin-left: 2rem;
   padding: 1rem;
+}
+
+.layout {
+  display: flex;
+  gap: 1rem;
+}
+
+.chat-area {
+  flex: 1;
+}
+
+.pdf-viewer {
+  width: 40%;
+  height: 500px;
+  border: 1px solid #ccc;
+}
+
+.manual-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.manual-item button {
+  margin-left: auto;
+}
+
+.pdf-icon {
+  font-size: 1.2rem;
 }
 
 h1 {

--- a/scripts/web_server.py
+++ b/scripts/web_server.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import re
-from fastapi import FastAPI
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
+import os
+import shutil
 import uvicorn
 
 from functions.chat_utils import (
@@ -13,7 +17,11 @@ from functions.chat_utils import (
     extract_url_from_source_documents,
 )
 
+manual_dir = "./manuals"
+
 app = FastAPI()
+app.mount("/manuals", StaticFiles(directory=manual_dir), name="manuals")
+
 chain = build_chat_chain()
 
 
@@ -40,6 +48,31 @@ def chat(request: ChatRequest):
         "image": image_path,
         "url": url_found,
     }
+
+
+@app.get("/manuals")
+def list_manuals():
+    files = [f for f in os.listdir(manual_dir) if f.lower().endswith(".pdf")]
+    return {"files": files}
+
+
+@app.post("/manuals")
+async def upload_manual(file: UploadFile = File(...)):
+    if not file.filename.lower().endswith(".pdf"):
+        raise HTTPException(status_code=400, detail="Only PDF files are allowed")
+    dest_path = os.path.join(manual_dir, file.filename)
+    with open(dest_path, "wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+    return {"success": True}
+
+
+@app.delete("/manuals/{filename}")
+def delete_manual(filename: str):
+    file_path = os.path.join(manual_dir, filename)
+    if not os.path.exists(file_path):
+        raise HTTPException(status_code=404, detail="File not found")
+    os.remove(file_path)
+    return {"success": True}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend FastAPI server to manage manuals via GET/POST/DELETE
- mount manuals folder as static files
- update tRPC router with procedures to list and delete manuals
- add configuration page for managing PDF manuals
- display returned manual PDFs beside the chat
- tweak global styles for layout and pdf lists

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b73b87e0832ea96f73fd595db498