### PR TITLE
Improve chat layout and auto-scroll

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { trpc } from '../utils/trpc'
 
@@ -10,6 +10,14 @@ export default function Home() {
     url?: string | null
   }[]>([])
   const [pdfUrl, setPdfUrl] = useState<string | null>(null)
+  const chatBoxRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const box = chatBoxRef.current
+    if (box) {
+      box.scrollTop = box.scrollHeight
+    }
+  }, [messages])
 
   const mutation = trpc.sendMessage.useMutation({
     onSuccess(data) {
@@ -30,7 +38,7 @@ export default function Home() {
       <a href="/config" className="link-button">Configuración</a>
       <div className="layout">
         <div className="chat-area">
-          <div className="chat-box">
+          <div className="chat-box" ref={chatBoxRef}>
             {messages.map((m, i) => (
               <div key={i} className="message">
                 <div className="user"><strong>Usuario:</strong> {m.user}</div>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -11,17 +11,18 @@ body {
   padding: 1rem;
 }
 
+
 .layout {
   display: flex;
   gap: 1rem;
 }
 
 .chat-area {
-  flex: 1;
+  flex: 0 0 33%;
 }
 
 .pdf-viewer {
-  width: 40%;
+  width: 66%;
   height: 500px;
   border: 1px solid #ccc;
 }
@@ -112,6 +113,7 @@ button {
   border-radius: 4px;
   text-decoration: none;
   display: inline-block;
+  margin-bottom: 1rem;
 }
 
 .link-button:hover {


### PR DESCRIPTION
## Summary
- allocate 1/3 width to chat and 2/3 width to PDF preview
- scroll chat to latest message automatically
- add spacing to configuration button

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c9b6c750832eb73f2d843b3109ae