### PR TITLE
Add responsive layout and header

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -4,6 +4,9 @@ import { trpc } from '../utils/trpc'
 import { httpBatchLink } from '@trpc/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useState } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import kaltireLogo from '../images/kaltire_logo.png'
 
 function MyApp({ Component, pageProps }: AppProps) {
   const [queryClient] = useState(() => new QueryClient())
@@ -18,7 +21,16 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <trpc.Provider client={trpcClient} queryClient={queryClient}>
       <QueryClientProvider client={queryClient}>
-        <Component {...pageProps} />
+        <div className="app-container">
+          <header className="header">
+            <Image src={kaltireLogo} alt="Kaltire" className="logo" />
+            <nav>
+              <Link href="/" className="nav-link">Inicio</Link>
+              <Link href="/config" className="nav-link">Configuración</Link>
+            </nav>
+          </header>
+          <Component {...pageProps} />
+        </div>
       </QueryClientProvider>
     </trpc.Provider>
   )

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -36,7 +36,6 @@ export default function Home() {
   return (
     <div className="container">
       <h1>MTG Security Chatbot</h1>
-      <a href="/config" className="link-button">Configuration</a>
       <div className="layout">
         <div className="chat-area">
           <div className="chat-box" ref={chatBoxRef}>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,8 +1,45 @@
 body {
   margin: 0;
-  font-family: sans-serif;
+  font-family: Arial, sans-serif;
+  font-size: 11px;
   background-color: #ffffff;
   color: #000000;
+  min-height: 100vh;
+}
+
+.app-container {
+  min-height: 90vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  background-color: #ff6900;
+  padding: 0.5rem 1rem;
+  display: flex;
+  align-items: center;
+}
+
+.logo {
+  height: 40px;
+  width: auto;
+  margin-right: 1rem;
+}
+
+.header nav {
+  margin-left: auto;
+  display: flex;
+  gap: 1rem;
+}
+
+.nav-link {
+  color: #ffffff;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.nav-link:hover {
+  text-decoration: underline;
 }
 
 .container {
@@ -10,16 +47,22 @@ body {
   margin-left: 5rem;
   margin-right: 5rem;
   padding: 1rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 
 .layout {
   display: flex;
   gap: 1rem;
+  height: 100%;
 }
 
 .chat-area {
   flex: 0 0 45%;
+  display: flex;
+  flex-direction: column;
 }
 
 .pdf-viewer {
@@ -51,10 +94,11 @@ h1 {
   background-color: #fff4e5;
   border: 1px solid #ffc488;
   padding: 1rem;
-  height: 500px;
+  flex: 1;
   overflow-y: auto;
   margin-bottom: 1rem;
   border-radius: 8px;
+  min-height: 0;
 }
 
 .message {
@@ -122,4 +166,29 @@ button {
 
 button:hover {
   background-color: #ffa940;
+}
+
+@media (max-width: 768px) {
+  .layout {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .chat-area {
+    flex: 0 0 90%;
+  }
+
+  .pdf-viewer {
+    display: none;
+  }
+}
+
+@media (orientation: portrait) and (min-width: 769px) {
+  .pdf-viewer {
+    display: none;
+  }
+
+  .chat-area {
+    flex: 1;
+  }
 }


### PR DESCRIPTION
## Summary
- use Arial 11pt font and add Kaltire header with navigation
- adjust container layout to fill 90% of the viewport
- make chat box flexible and responsive
- hide PDF on mobile/portrait screens
- remove configuration link from home (now in header)

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684aeddef274832e877c3311fedd3b88