### PR TITLE
Add tRPC client and fix transformer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ npm install
 npm run dev
 ```
 
+If you encounter an error like `Module not found: Can't resolve '@trpc/client'`
+when building, make sure the dependencies are installed by running `npm install`
+inside the `frontend` directory.
+
 Then open `http://localhost:3000` in your browser. The interface uses Kaltire's colours (black `#000000`, orange `#ff6900`, and white).
 
 The frontend is built with Next.js.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,11 +12,14 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.29.0",
+    "@trpc/client": "^10.0.0",
+    "@trpc/react-query": "^10.0.0",
     "next": "13.4.19",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-markdown": "^8.0.7",
     "remark-gfm": "^4.0.1",
+    "superjson": "^2.2.0",
     "zod": "^3.22.0"
   },
   "devDependencies": {

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -2,20 +2,39 @@ import '../styles/globals.css'
 import type { AppProps } from 'next/app'
 import Link from 'next/link'
 import Image from 'next/image'
+import { useState } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { httpBatchLink } from '@trpc/client'
+import superjson from 'superjson'
 import kaltireLogo from '../images/kaltire_logo.png'
+import { trpc } from '../utils/trpc'
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const [queryClient] = useState(() => new QueryClient())
+  const [trpcClient] = useState(() =>
+    trpc.createClient({
+      transformer: superjson,
+      links: [
+        httpBatchLink({ url: '/api/trpc' }),
+      ],
+    })
+  )
+
   return (
-    <div className="app-container">
-      <header className="header">
-        <Image src={kaltireLogo} alt="Kaltire" className="logo" />
-        <nav>
-          <Link href="/" className="nav-link">Chatbot</Link>
-          <Link href="/config" className="nav-link">Configuration</Link>
-        </nav>
-      </header>
-      <Component {...pageProps} />
-    </div>
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>
+        <div className="app-container">
+          <header className="header">
+            <Image src={kaltireLogo} alt="Kaltire" className="logo" />
+            <nav>
+              <Link href="/" className="nav-link">Chatbot</Link>
+              <Link href="/config" className="nav-link">Configuration</Link>
+            </nav>
+          </header>
+          <Component {...pageProps} />
+        </div>
+      </QueryClientProvider>
+    </trpc.Provider>
   )
 }
 

--- a/frontend/src/utils/trpc.ts
+++ b/frontend/src/utils/trpc.ts
@@ -1,0 +1,5 @@
+import { createTRPCReact } from '@trpc/react-query';
+// Placeholder type until server router is defined
+export type AppRouter = any;
+
+export const trpc = createTRPCReact<AppRouter>();


### PR DESCRIPTION
## Summary
- add tRPC dependencies
- setup `trpc` React client with `superjson` transformer
- clarify that `npm install` must be run before building frontend

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c44430828832e9fd64e0874b7126c