### PR TITLE
Add chat clear button and limit history

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -81,7 +81,7 @@ export default function Home() {
                 onClick={handleClear}
                 title="Limpiar historial"
               >
-                🖌️
+                🗑️
               </button>
             {/* </div> */}
           </form>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -15,6 +15,11 @@ export default function Home() {
   const [pdfUrl, setPdfUrl] = useState<string | null>(null)
   const chatBoxRef = useRef<HTMLDivElement>(null)
 
+  const handleClear = () => {
+    setMessages([])
+    setPdfUrl(null)
+  }
+
   useEffect(() => {
     const box = chatBoxRef.current
     if (box) {
@@ -24,10 +29,13 @@ export default function Home() {
 
   const mutation = trpc.sendMessage.useMutation({
     onSuccess(data) {
-      setMessages(prev => [
-        ...prev,
-        { user: input, bot: data.response, url: data.url },
-      ])
+      setMessages(prev => {
+        const newMsgs = [
+          ...prev,
+          { user: input, bot: data.response, url: data.url },
+        ]
+        return newMsgs.slice(-5)
+      })
       if (data.url) {
         setPdfUrl(data.url.replace('./', `${baseURL}/`))
       }
@@ -67,6 +75,14 @@ export default function Home() {
                 placeholder="Escribe tu mensaje"
                 />
               <button type="submit">Enviar</button>
+              <button
+                type="button"
+                className="clear-button"
+                onClick={handleClear}
+                title="Limpiar historial"
+              >
+                🖌️
+              </button>
             {/* </div> */}
           </form>
         </div>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -155,6 +155,14 @@ button {
   cursor: pointer;
 }
 
+.clear-button {
+  padding: 0.5rem;
+}
+
+.clear-button:hover {
+  background-color: #ffa940;
+}
+
 .link-button {
   background-color: #ff6900;
   color: white;

--- a/functions/chat_utils.py
+++ b/functions/chat_utils.py
@@ -13,7 +13,7 @@ from typing import List, Optional
 import matplotlib.pyplot as plt
 from langchain.chains import ConversationalRetrievalChain, LLMChain
 from langchain.chains.combine_documents.stuff import StuffDocumentsChain
-from langchain.memory import ConversationBufferMemory
+from langchain.memory import ConversationBufferWindowMemory
 from langchain.prompts import PromptTemplate
 from langchain.vectorstores import FAISS
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
@@ -100,7 +100,8 @@ def build_chat_chain(index_dir: str = "./rag_index") -> ConversationalRetrievalC
         document_variable_name="context",
     )
 
-    memory = ConversationBufferMemory(
+    memory = ConversationBufferWindowMemory(
+        k=5,
         memory_key="chat_history",
         return_messages=True,
         output_key="answer",


### PR DESCRIPTION
## Summary
- trim chat memory on backend to 5 messages
- keep only last 5 messages on the frontend
- add brush button to clear the conversation

## Testing
- `python -m scripts.chatbot --help` *(fails: OPEN_AI_KEY environment variable not set)*
- `npm run build` in `frontend` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c910b6700832eb30600a71bee7f71